### PR TITLE
Fix code scanning alert no. 3: Flask app is run in debug mode

### DIFF
--- a/nfcapi.py
+++ b/nfcapi.py
@@ -45,6 +45,9 @@ def start_nfc_reader():
     poll_nfc_thread.daemon = True  # Allow thread to exit when the program exits
     poll_nfc_thread.start()
 
+import os
+
 if __name__ == '__main__':
     start_nfc_reader()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode, host='0.0.0.0', port=5000)


### PR DESCRIPTION
Fixes [https://github.com/ne0ekspert/voice-activated-kiosk/security/code-scanning/3](https://github.com/ne0ekspert/voice-activated-kiosk/security/code-scanning/3)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can easily switch between development and production environments without changing the code.

1. Import the `os` module to access environment variables.
2. Use the `os.getenv` method to get the value of an environment variable (e.g., `FLASK_DEBUG`).
3. Set the `debug` parameter of `app.run` based on the value of the environment variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
